### PR TITLE
upgrading tensorflow to 2.5.0

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,3 @@
+template: |
+  ## What's Changed
+  $CHANGES

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -20,6 +20,13 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Patch requirements
+      run: |
+        TFSTRING=`grep "tensorflow" requirements.txt`
+        TFVERSION=`echo $TFSTRING | cut -f2 -d "<" | cut -f2 -d "="`
+        # ugly sed because macos does not accept -i
+        sed "s/$TFSTRING/tensorflow==$TFVERSION/" requirements.txt > new_requirements.txt
+        mv new_requirements.txt requirements.txt
     - name: Install OS requirements
       uses: mstksg/get-package@v1
       with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -4,17 +4,20 @@
 [![codecov](https://codecov.io/gh/Quantum-TII/qibotf/branch/main/graph/badge.svg?token=0MRXUA7SZ0)](https://codecov.io/gh/Quantum-TII/qibotf)
 [![DOI](https://zenodo.org/badge/241307936.svg)](https://zenodo.org/badge/latestdoi/241307936)
 
-## Documentation
-
 This package provides acceleration features for [Qibo](https://github.com/Quantum-TII/qibo) using [TensorFlow](https://github.com/tensorflow/tensorflow) custom operators.
 
-Qibo documentation is available at [qibo.readthedocs.io](https://qibo.readthedocs.io).
+## Documentation
 
-- [Installation](https://qibo.readthedocs.io/en/stable/installation.html)
-- [Documentation](https://qibo.readthedocs.io/)
-- [Components](https://qibo.readthedocs.io/en/stable/qibo.html)
-- [Examples](https://qibo.readthedocs.io/en/stable/examples.html)
-- [Benchmarks](https://qibo.readthedocs.io/en/stable/benchmarks.html)
+The qibotf backend documentation is available at [qibo.readthedocs.io](https://qibo.readthedocs.io/en/stable/installation.html).
+
+## Support and requirements
+
+Here a compatibility matrix for the qibotf versions:
+
+| qibotf | tensorflow | OS Hardware                |
+|--------|------------|----------------------------|
+| 0.0.2  | 2.5.0      | linux (cpu/gpu), mac (cpu) |
+| 0.0.1  | 2.4.1      | linux (cpu/gpu), mac (cpu) |
 
 ## Citation policy
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ The qibotf backend documentation is available at [qibo.readthedocs.io](https://q
 
 Here a compatibility matrix for the qibotf versions:
 
-| qibotf | tensorflow | OS Hardware                |
-|--------|------------|----------------------------|
-| 0.0.2  | 2.5.0      | linux (cpu/gpu), mac (cpu) |
-| 0.0.1  | 2.4.1      | linux (cpu/gpu), mac (cpu) |
+| qibotf | tensorflow                       | OS Hardware                |
+|--------|----------------------------------|----------------------------|
+| 0.0.2  | 2.5.0 for pip (>=2.2 for source) | linux (cpu/gpu), mac (cpu) |
+| 0.0.1  | 2.4.1 for pip (>=2.2 for source) | linux (cpu/gpu), mac (cpu) |
 
 ## Citation policy
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # Runtime requirements for qibotf
 
-tensorflow==2.4.1
+tensorflow==2.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # Runtime requirements for qibotf
 
-tensorflow==2.5.0
+tensorflow>=2.2,<=2.5.0

--- a/setup.py
+++ b/setup.py
@@ -11,18 +11,34 @@ import sys
 PACKAGE = "qibotf"
 
 
+# extract tensorflow version
+try:
+    import tensorflow as tf
+    TF_VERSION = tf.__version__
+except:
+    raise ModuleNotFoundError('Please install TensorFlow before qibotf.')
+
+
+# replace tensorflow placehold version in __init__.py
+PLACEHOLDER = os.path.join("src", PACKAGE, "__init__.py.in")
+VERSIONFILE = os.path.join("src", PACKAGE, "__init__.py")
+with open(PLACEHOLDER, 'r') as f:
+    content = f.read()
+    content = content.replace('TF_VERSION', TF_VERSION)
+with open(VERSIONFILE, 'w') as f:
+    f.write(content)
+
+
 # Returns the version
 def get_version():
     """ Gets the version from the package's __init__ file
     if there is some problem, let it happily fail """
-    VERSIONFILE = os.path.join("src", PACKAGE, "__init__.py")
     initfile_lines = open(VERSIONFILE, "rt").readlines()
     VSRE = r"^__version__ = ['\"]([^'\"]*)['\"]"
     for line in initfile_lines:
         mo = re.search(VSRE, line, re.M)
         if mo:
             return mo.group(1)
-
 
 
 # Custom compilation step

--- a/src/qibotf/__init__.py
+++ b/src/qibotf/__init__.py
@@ -1,4 +1,4 @@
 __version__ = "0.0.2-dev"
 
 # tf version used during the compilation of custom operators
-__target_tf_version__ = '2.4.1'
+__target_tf_version__ = '2.5.0'

--- a/src/qibotf/__init__.py
+++ b/src/qibotf/__init__.py
@@ -1,1 +1,4 @@
 __version__ = "0.0.2-dev"
+
+# tf version used during the compilation of custom operators
+__target_tf_version__ = '2.4.1'

--- a/src/qibotf/__init__.py.in
+++ b/src/qibotf/__init__.py.in
@@ -1,4 +1,4 @@
 __version__ = "0.0.2-dev"
 
 # tf version used during the compilation of custom operators
-__target_tf_version__ = '2.5.0'
+__target_tf_version__ = 'TF_VERSION'

--- a/src/qibotf/custom_operators/python/ops/qibo_tf_custom_operators.py
+++ b/src/qibotf/custom_operators/python/ops/qibo_tf_custom_operators.py
@@ -1,5 +1,15 @@
 """Use ops in python."""
 import tensorflow as tf
+from qibotf import __target_tf_version__, __version__
+if tf.__version__ < __target_tf_version__:  # pragma: no cover
+    raise RuntimeError(
+        f"qibotf {__version__} requires TensorFlow {__target_tf_version__}."
+        "Please upgrade TensorFlow or downgrade qibotf.")
+elif tf.__version__ > __target_tf_version__:  # pragma: no cover
+    raise RuntimeError(
+        f"qibotf {__version__} requires TensorFlow {__target_tf_version__}."
+        "Please upgrade qibotf or downgrade TensorFlow.")
+
 from tensorflow.python.framework import load_library  # pylint: disable=no-name-in-module
 from tensorflow.python.platform import resource_loader  # pylint: disable=no-name-in-module
 

--- a/src/qibotf/custom_operators/python/ops/qibo_tf_custom_operators.py
+++ b/src/qibotf/custom_operators/python/ops/qibo_tf_custom_operators.py
@@ -1,14 +1,10 @@
 """Use ops in python."""
 import tensorflow as tf
 from qibotf import __target_tf_version__, __version__
-if tf.__version__ < __target_tf_version__:  # pragma: no cover
+if tf.__version__ != __target_tf_version__:  # pragma: no cover
     raise RuntimeError(
-        f"qibotf {__version__} requires TensorFlow {__target_tf_version__}."
-        "Please upgrade TensorFlow or downgrade qibotf.")
-elif tf.__version__ > __target_tf_version__:  # pragma: no cover
-    raise RuntimeError(
-        f"qibotf {__version__} requires TensorFlow {__target_tf_version__}."
-        "Please upgrade qibotf or downgrade TensorFlow.")
+        f"qibotf and TensorFlow versions do not match. "
+        "Please check the qibotf documentation.")
 
 from tensorflow.python.framework import load_library  # pylint: disable=no-name-in-module
 from tensorflow.python.platform import resource_loader  # pylint: disable=no-name-in-module


### PR DESCRIPTION
In this PR:
- upgrade requirement from 2.4.1 to 2.5.0 
- include version checks, in order to tell the user what is wrong.
- extend python tests and wheels to python3.9
- updated readme with compatibility table.